### PR TITLE
More windows fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "test": "mocha --compilers js:babel/register",
     "build:bin:compile": "babel \"bin/tw*\" -d build",
-    "build:bin:rename": "renamer -f '.js' -r '' 'build/bin/*.js' -v",
-    "build:bin:fix-binary": "replace '#!/usr/bin/env babel-node --' '#!/usr/bin/env node' build/bin -r",
+    "build:bin:rename": "renamer -f \".js\" -r '' \"build/bin/*.js\" -v",
+    "build:bin:fix-binary": "replace \"#!/usr/bin/env babel-node --\" \"#!/usr/bin/env node\" build/bin -r",
     "build:bin:chmod": "node -e \"var fs = require('fs'); fs.readdirSync('build/bin').forEach(function(f){ console.log('chmod 0775 %s', f); fs.chmod('build/bin/'+f, 0775); });\"",
     "build:bin": "npm run build:bin:compile && npm run build:bin:rename && npm run build:bin:fix-binary && npm run build:bin:chmod",
     "build:src": "babel src -d build/src",


### PR DESCRIPTION
It appears to build everything correctly but fails at the chmod: 

Latest error: 

```
> tw-beta@0.2.0 build:bin:chmod C:\Users\hhjones\Documents\VersionControl\Amazon
\TW-CLI
> node -e "var fs = require('fs'); fs.readdirSync('build/bin').forEach(function(
f){ console.log('chmod 0775 %s', f); fs.chmod('build/bin/'+f, 0775); });"

chmod 0775 tw''
chmod 0775 tw-clear''
chmod 0775 tw-config''
chmod 0775 tw-history''
chmod 0775 tw-hook-commit-msg''
chmod 0775 tw-hook-post-commit''
chmod 0775 tw-info''
chmod 0775 tw-install-hooks''
chmod 0775 tw-log''
chmod 0775 tw-login''
chmod 0775 tw-logs''
chmod 0775 tw-open''
chmod 0775 tw-projects''
chmod 0775 tw-redo''
chmod 0775 tw-reset''
chmod 0775 tw-status''
chmod 0775 tw-task''
chmod 0775 tw-tasklists''
chmod 0775 tw-tasks''
chmod 0775 tw-timer''
chmod 0775 tw-undo''
npm ERR! Windows_NT 6.1.7601
npm ERR! argv "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs
\\node_modules\\npm\\bin\\npm-cli.js" "install" "-g"
npm ERR! node v0.12.2
npm ERR! npm  v2.7.4
npm ERR! path C:\Users\hhjones\AppData\Roaming\npm\node_modules\tw-beta\build\bi
n\tw
npm ERR! code ENOENT
npm ERR! errno -4058

npm ERR! enoent ENOENT, chmod 'C:\Users\hhjones\AppData\Roaming\npm\node_modules
\tw-beta\build\bin\tw'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! Please include the following file with any support request:
npm ERR!     C:\Users\hhjones\Documents\VersionControl\Amazon\TW-CLI\npm-debug.l
og
```
